### PR TITLE
quiet pruning in qsearch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ void bench()
 
         u64 time_1 = now();
 
-        engine.start(board, visited, 8, TRUE);
+        engine.start(board, visited, 15, TRUE);
 
         u64 time_2 = now();
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -172,6 +172,10 @@ struct Thread {
             // Check if quiet
             int is_quiet = board.quiet(move);
 
+            // Quiet pruning in qsearch
+            if (is_qsearch && best > -WIN && board.is_checked && is_quiet)
+                break;
+
             // Late move pruning
             if (!is_pv && !board.is_checked && quiet_count > depth * depth + 1)
                 break;
@@ -214,7 +218,7 @@ struct Thread {
             // Principle variation search
             if (is_pv && (legals == 1 || score > alpha)) {
                 pvsearch:
-                score = -search(child, -beta, -alpha, ply + 1, depth_next, is_qsearch ? is_pv : TRUE);
+                score = -search(child, -beta, -alpha, ply + 1, depth_next, is_pv);
             }
 
             // Unmake


### PR DESCRIPTION
Elo   | 25.49 +- 11.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2526 W: 998 L: 813 D: 715
Penta | [118, 225, 448, 298, 174]
https://citrus610.pythonanywhere.com/test/19/