### PR TITLE
use tt score as better eval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -91,6 +91,9 @@ struct Thread {
             // Get eval
             eval = stack[ply].eval = board.eval();
 
+            if (tt.hash && tt.bound != eval > tt.score)
+                eval = tt.score;
+
             if (is_qsearch) {
                 // Standpat
                 best = eval;


### PR DESCRIPTION
Elo   | 39.79 +- 13.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1526 W: 618 L: 444 D: 464
Penta | [54, 130, 273, 200, 106]
https://citrus610.pythonanywhere.com/test/23/