### PR TITLE
iir

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -79,9 +79,13 @@ struct Thread {
         if (slot.hash == u16(board.hash)) {
             tt = slot;
 
+            // Cutoff
             if (!is_pv && depth <= tt.depth && tt.bound != tt.score < beta)
                 return tt.score;
         }
+        else
+            // Internal iterative reduction
+            depth -= depth > 3;
 
         // Static eval
         int eval;


### PR DESCRIPTION
Elo   | 6.30 +- 5.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.11 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9596 W: 3468 L: 3294 D: 2834
Penta | [496, 981, 1746, 1003, 572]
https://citrus610.pythonanywhere.com/test/39/