### PR TITLE
use log directly

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,10 +118,6 @@ int main() {
     for (int i = 0; i < 13; i++)
         for (int k = 0; k < 64; k++)
             KEYS[i][k] = rng();
-    
-    // Table
-    for (int i = 0; i < 256; i++)
-        LOG[i] = log(max(i, 1));
 
     // Search data
     Board board;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1,7 +1,5 @@
 #include "board.cpp"
 
-double LOG[256];
-
 // History
 typedef i16 HTable[12][64];
 
@@ -219,7 +217,7 @@ struct Thread {
 
             // Late move reduction
             if (depth > 2 && legals > 1 + !!ply * 2) {
-                int reduction = LOG[depth] * LOG[legals] * 0.3 + 1;
+                int reduction = log(depth) * log(legals) * 0.3 + 1;
 
                 if (is_quiet)
                     reduction -= move_scores[i] / 8192;


### PR DESCRIPTION
Elo   | 2.14 +- 4.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 13824 W: 4930 L: 4845 D: 4049
Penta | [742, 1390, 2586, 1429, 765]
https://citrus610.pythonanywhere.com/test/40/