### PR TITLE
pawn threat in mobility

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -215,6 +215,9 @@ struct Board {
         int phase = 0;
 
         for (int color = WHITE; color < 2; color++) {
+            // Enemy pawn attacks
+            u64 enemy_pawn_attacks = se(pieces[PAWN] & colors[!color]) | sw(pieces[PAWN] & colors[!color]);
+
             for (int type = PAWN; type < TYPE_NONE; type++) {
                 u64 mask = pieces[type] & colors[color];
 
@@ -234,7 +237,7 @@ struct Board {
                             (type != BISHOP) * rook(1ULL << square, colors[WHITE] | colors[BLACK]) |
                             (type != ROOK) * bishop(1ULL << square, colors[WHITE] | colors[BLACK]);
 
-                        eval += MOBILITY[type] * __builtin_popcountll(mobility & ~colors[color]);
+                        eval += MOBILITY[type] * __builtin_popcountll(mobility & ~colors[color] & ~enemy_pawn_attacks);
                     }
                 }
             }


### PR DESCRIPTION
eval-mobility-pawn-threa... vs main
Elo   | 7.12 +- 5.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10346 W: 3520 L: 3308 D: 3518
Penta | [453, 1078, 1940, 1208, 494]
https://analoghors.pythonanywhere.com/test/6890/