### PR TITLE
see pruning in pv search

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -101,7 +101,7 @@ struct Board {
         int from = move_from(move);
         int to = move_to(move);
 
-        if (move_promo(move) || to == enpassant)
+        if (move_promo(move) || (board[from] < WHITE_KNIGHT && to == enpassant))
             return TRUE;
 
         if ((threshold -= VALUE[board[to] / 2]) > 0)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -174,7 +174,7 @@ struct Thread {
             // Check if quiet
             int is_quiet = board.quiet(move);
 
-            // Quiet and bad noisies pruning in qsearch
+            // Quiet pruning and SEE pruning in qsearch
             if (!depth && best > -WIN && (board.checkers && is_quiet || move_scores[i] < -1e6))
                 break;
 
@@ -184,6 +184,10 @@ struct Thread {
 
             // Late move pruning
             if (!is_pv && !board.checkers && quiet_count > depth * depth + 1 && is_quiet)
+                continue;
+
+            // SEE pruning
+            if (ply && best > -WIN && move_scores[i] < 1e6 && !board.see(move, -80 * depth))
                 continue;
 
             // Make


### PR DESCRIPTION
see-pruning-pvsearch vs see
Elo   | 29.57 +- 11.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1802 W: 643 L: 490 D: 669
Penta | [43, 172, 357, 247, 82]
https://analoghors.pythonanywhere.com/test/6902/