### PR TITLE
eval king on semi open and open file

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -283,6 +283,14 @@ struct Board {
                             (type != ROOK) * bishop(1ull << square, colors[WHITE] | colors[BLACK]);
 
                         eval += MOBILITY[type] * __builtin_popcountll(mobility & ~colors[color] & ~enemy_pawn_attacks);
+
+                        // Open file
+                        if (!(0x101010101010101ull << square % 8 & pieces[PAWN]))
+                            eval += (type > QUEEN) * KING_OPEN;
+
+                        // Semi open file
+                        if (!(0x101010101010101ull << square % 8 & pieces[PAWN] & colors[color]))
+                            eval += (type > QUEEN) * KING_SEMI_OPEN;
                     }
                 }
             }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -31,5 +31,7 @@ int MOBILITY[] = { 0, S(8, 5), S(7, 7), S(3, 5), S(3, 2), S(-5, -1) };
 int PASSER[] = { 0, S(0, 10), S(-5, 20), S(-10, 30), S(10, 50), S(15, 100), S(25, 150), 0 };
 
 #define BISHOP_PAIR S(25, 55)
+#define KING_OPEN S(-75, 5)
+#define KING_SEMI_OPEN S(-30, 15)
 
 #define TEMPO 20


### PR DESCRIPTION
king-open-file vs main
Elo   | 26.12 +- 10.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2052 W: 722 L: 568 D: 762
Penta | [45, 208, 413, 268, 92]
https://analoghors.pythonanywhere.com/test/6907/