### PR TITLE
rook on semi open and open files

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -286,11 +286,11 @@ struct Board {
 
                         // Open file
                         if (!(0x101010101010101ull << square % 8 & pieces[PAWN]))
-                            eval += (type > QUEEN) * KING_OPEN;
+                            eval += (type > QUEEN) * KING_OPEN + (type == ROOK) * ROOK_OPEN;
 
                         // Semi open file
                         if (!(0x101010101010101ull << square % 8 & pieces[PAWN] & colors[color]))
-                            eval += (type > QUEEN) * KING_SEMI_OPEN;
+                            eval += (type > QUEEN) * KING_SEMI_OPEN + (type == ROOK) * ROOK_SEMI_OPEN;
                     }
                 }
             }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -33,5 +33,7 @@ int PASSER[] = { 0, S(0, 10), S(-5, 20), S(-10, 30), S(10, 50), S(15, 100), S(25
 #define BISHOP_PAIR S(25, 55)
 #define KING_OPEN S(-75, 5)
 #define KING_SEMI_OPEN S(-30, 15)
+#define ROOK_OPEN S(25, 5)
+#define ROOK_SEMI_OPEN S(10, 15)
 
 #define TEMPO 20


### PR DESCRIPTION
rook-open-file vs main
Elo   | 20.15 +- 9.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2762 W: 959 L: 799 D: 1004
Penta | [70, 302, 534, 348, 127]
https://analoghors.pythonanywhere.com/test/6908/