### PR TITLE
eval scale

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -315,7 +315,10 @@ struct Board {
             eval = -eval;
         }
 
-        eval = (i16(eval) * phase + (eval + 0x8000 >> 16) * (24 - phase)) / 24;
+        // Scaling
+        int x = 8 - POPCNT(pieces[PAWN] & colors[eval < 0]);
+
+        eval = (i16(eval) * phase + (eval + 0x8000 >> 16) * (128 - x * x) / 128 * (24 - phase)) / 24;
 
         return (stm ? -eval : eval) + TEMPO;
     }


### PR DESCRIPTION
eval-scale vs main
Elo   | 20.75 +- 9.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.69 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2414 W: 800 L: 656 D: 958
Penta | [63, 244, 479, 328, 93]
https://analoghors.pythonanywhere.com/test/6913/