### PR TITLE
pawns protected

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -254,10 +254,14 @@ struct Board {
         for (int color = WHITE; color < 2; color++) {
             u64 pawns[] = { pieces[PAWN] & colors[WHITE], pieces[PAWN] & colors[BLACK] };
             u64 pawns_threats = se(pawns[!color]) | sw(pawns[!color]);
+            u64 pawns_attacks = ne(pawns[color]) | nw(pawns[color]);
             u64 pawns_phalanx = west(pawns[color]) & pawns[color];
 
             // Bishop pair
             eval += (POPCNT(pieces[BISHOP] & colors[color]) > 1) * BISHOP_PAIR;
+
+            // Pawn protected
+            eval += POPCNT(pawns[color] & pawns_attacks) * PAWN_PROTECTED;
 
             for (int type = PAWN; type < TYPE_NONE; type++) {
                 u64 mask = pieces[type] & colors[color];

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -17,6 +17,7 @@ int MATERIAL[] = { S(89, 147), S(350, 521), S(361, 521), S(479, 956), S(1046, 17
 #define KING_SEMI_OPEN S(-30, 15)
 #define ROOK_OPEN S(25, 5)
 #define ROOK_SEMI_OPEN S(10, 15)
+#define PAWN_PROTECTED S(12, 16)
 
 #define TEMPO 20
 


### PR DESCRIPTION
pawn-protected vs main
Elo   | 29.81 +- 11.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1764 W: 596 L: 445 D: 723
Penta | [38, 178, 332, 263, 71]
https://analoghors.pythonanywhere.com/test/6917/