### PR TITLE
pawn shield

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -305,6 +305,10 @@ struct Board {
                         // Semi open file
                         if (!(0x101010101010101ull << square % 8 & pawns[color]))
                             eval += (type > QUEEN) * KING_SEMI_OPEN + (type == ROOK) * ROOK_SEMI_OPEN;
+
+                        // Pawn shield
+                        if (type > QUEEN && square < A2)
+                            eval += POPCNT(pawns[color] & 0x70700ull << 5 * (square % 8 > 2)) * PAWN_SHIELD;
                     }
                 }
             }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -18,6 +18,7 @@ int MATERIAL[] = { S(89, 147), S(350, 521), S(361, 521), S(479, 956), S(1046, 17
 #define ROOK_OPEN S(25, 5)
 #define ROOK_SEMI_OPEN S(10, 15)
 #define PAWN_PROTECTED S(12, 16)
+#define PAWN_SHIELD S(30, -10)
 
 #define TEMPO 20
 


### PR DESCRIPTION
pawn-shield vs main
Elo   | 49.39 +- 14.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1034 W: 384 L: 238 D: 412
Penta | [13, 93, 196, 165, 50]
https://analoghors.pythonanywhere.com/test/6918/