### PR TITLE
double extension

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -199,7 +199,9 @@ struct Thread {
 
             if (ply && depth > 7 && !excluded && move == tt.move && tt.depth > depth - 4 && tt.bound) {
                 int singular_beta = tt.score - depth * 2;
-                extension = search(board, singular_beta - 1, singular_beta, ply, (depth - 1) / 2, FALSE, FALSE, move) < singular_beta;
+                int singular_score = search(board, singular_beta - 1, singular_beta, ply, (depth - 1) / 2, FALSE, FALSE, move);
+
+                extension = (singular_score < singular_beta) + (!is_pv && singular_score + 16 < singular_beta);
             }
 
             // Make


### PR DESCRIPTION
double-extension vs main
Elo   | 10.73 +- 6.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5310 W: 1655 L: 1491 D: 2164
Penta | [143, 567, 1097, 679, 169]
https://analoghors.pythonanywhere.com/test/6936/