### PR TITLE
king attack

### DIFF
--- a/minifier/eval.h
+++ b/minifier/eval.h
@@ -75,7 +75,13 @@ inline const std::vector<Param> PARAMS = {
         .data = {
             0, S(50, 25), S(50, 50), S(80, 25), S(75, 0)
         }
-    }
+    },
+    Param {
+        .name = "KING_ATTACK",
+        .data = {
+            0, S(20, 0), S(25, 0), S(25, 0), S(25, 0)
+        }
+    },
 };
 
 inline Compressed get_compressed_data(std::vector<int> data)

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -298,7 +298,10 @@ struct Board {
 
                         // Pawn threats
                         if (1ull << square & pawns_threats)
-                            eval -= get_data(type + INDEX_THREAT);
+                            eval -= get_data(type + INDEX_THREAT) + OFFSET_THREAT;
+
+                        // King attacker
+                        eval += POPCNT(mobility & king(pieces[KING] & colors[!color])) * (get_data(type + INDEX_KING_ATTACK) + OFFSET_KING_ATTACK);
                     }
                 }
             }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -22,9 +22,9 @@ int MATERIAL[] = { S(89, 147), S(350, 521), S(361, 521), S(479, 956), S(1046, 17
 
 #define TEMPO 20
 
-#define DATA_STR "/,,.04//-/02341 /11111.%/.--/101121//.+-.0.+.444#\"#$%&&# #$&&&%#\"$%$%$&#\"#$%&%%#\"##$$%&%\"&#  \"&$%-,(( \"\"! $%' !\"#%*/ RRpk++**+.++&(*./,+,)*+++++-(()+--., #(-002/%)+.0/-%&&%$%%%%\"$&((%$\"$%%&&&%$%&&%$%%$\"$%&''%$ $&'''$ !&(&#  \"$&*4>  !\"*/4 9R9 "
+#define DATA_STR "/,,.04//-/02341 /11111.%/.--/101121//.+-.0.+.444#\"#$%&&# #$&&&%#\"$%$%$&#\"#$%&%%#\"##$$%&%\"&#  \"&$%-,(( \"\"! $%' !\"#%*/ RRpk 4999++**+.++&(*./,+,)*+++++-(()+--., #(-002/%)+.0/-%&&%$%%%%\"$&((%$\"$%%&&&%$%&&%$%%$\"$%&''%$ $&'''$ !&(&#  \"$&*4>  !\"*/4 9R9      "
 
-#define INDEX_EG 121
+#define INDEX_EG 126
 
 #define INDEX_PST_RANK 0
 #define INDEX_PST_FILE 48
@@ -32,6 +32,7 @@ int MATERIAL[] = { S(89, 147), S(350, 521), S(361, 521), S(479, 956), S(1046, 17
 #define INDEX_PASSER 102
 #define INDEX_PHALANX 109
 #define INDEX_THREAT 116
+#define INDEX_KING_ATTACK 121
 
 #define OFFSET_PST_RANK S(-15, -11)
 #define OFFSET_PST_FILE S(-4, -5)
@@ -39,6 +40,7 @@ int MATERIAL[] = { S(89, 147), S(350, 521), S(361, 521), S(479, 956), S(1046, 17
 #define OFFSET_PASSER S(-2, 0)
 #define OFFSET_PHALANX S(0, 0)
 #define OFFSET_THREAT S(0, 0)
+#define OFFSET_KING_ATTACK S(0, 0)
 
 int get_data(int index) {
     auto data = DATA_STR;


### PR DESCRIPTION
king-attack vs main
Elo   | 21.32 +- 9.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2448 W: 830 L: 680 D: 938
Penta | [52, 244, 530, 298, 100]
https://analoghors.pythonanywhere.com/test/6941/