### PR TITLE
pawn doubled

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -249,6 +249,9 @@ struct Board {
             // Pawn protected
             eval += POPCNT(pawns[color] & pawns_attacks) * PAWN_PROTECTED;
 
+            // Pawn doubled
+            eval -= POPCNT(pawns[color] & (north(pawns[color]) | north(north(pawns[color])))) * PAWN_DOUBLED;
+
             for (int type = PAWN; type < TYPE_NONE; type++) {
                 u64 mask = pieces[type] & colors[color];
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -18,6 +18,7 @@ int MATERIAL[] = { S(89, 147), S(350, 521), S(361, 521), S(479, 956), S(1046, 17
 #define ROOK_OPEN S(25, 5)
 #define ROOK_SEMI_OPEN S(10, 15)
 #define PAWN_PROTECTED S(12, 16)
+#define PAWN_DOUBLED S(12, 40)
 #define PAWN_SHIELD S(30, -10)
 
 #define TEMPO 20


### PR DESCRIPTION
pawn-doubled vs main
Elo   | 12.71 +- 7.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4568 W: 1398 L: 1231 D: 1939
Penta | [134, 492, 897, 595, 166]
https://analoghors.pythonanywhere.com/test/6948/