### PR TITLE
tt prefetch

### DIFF
--- a/minifier/mini.h
+++ b/minifier/mini.h
@@ -122,6 +122,7 @@ const inline std::vector<std::string> KEYWORDS_SKIP = {
     "__builtin_ctzll",
     "__builtin_popcountll",
     "__builtin_bswap64",
+    "__builtin_prefetch",
     "vector",
     "abs",
     "istream",

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -147,10 +147,12 @@ struct Board {
         if (from == A8 || to == A8) castled |= CASTLED_BQ;
 
         hash ^= KEYS[PIECE_NONE][castled];
+        hash ^= KEYS[PIECE_NONE][0];
+
+        __builtin_prefetch(&TTABLE[hash >> TT_SHIFT]);
 
         // Update side to move
         stm ^= 1;
-        hash ^= KEYS[PIECE_NONE][0];
 
         // In check
         checkers = attackers(LSB(pieces[KING] & colors[stm])) & colors[!stm];

--- a/src/chess.cpp
+++ b/src/chess.cpp
@@ -245,6 +245,23 @@ u64 king(u64 mask, u64 occupied = 0) {
     return mask << 8 | mask >> 8 | (mask >> 1 | mask >> 9 | mask << 7) & ~0x8080808080808080 | (mask << 1 | mask << 9 | mask >> 7) & ~0x101010101010101;
 }
 
+// Shared states
+struct TTEntry {
+    u16 key;
+    u16 move;
+    i16 score;
+    u8 depth;
+    u8 bound;
+};
+
+TTEntry* TTABLE;
+u16 BEST_MOVE;
+u64 LIMIT_SOFT;
+u64 LIMIT_HARD;
+u64 VISITED[STACK_SIZE];
+int VISITED_COUNT;
+int RUNNING;
+
 #ifdef OB
 void print_bitboard(u64 bitboard) {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -7,34 +7,17 @@ void update_history(i16& entry, int bonus) {
     entry += bonus - entry * abs(bonus) / HIST_MAX;
 }
 
-// Shared states
-struct TTEntry {
-    u16 key;
-    u16 move;
-    i16 score;
-    u8 depth;
-    u8 bound;
-};
-
-TTEntry* TTABLE;
-int RUNNING;
-u64 LIMIT_SOFT;
-u64 LIMIT_HARD;
-u16 BEST_MOVE;
-u64 VISITED[STACK_SIZE];
-int VISITED_COUNT;
-
 // Search thread
 struct Thread {
-    u64 nodes {};
     u16 pv;
     i16 qhist[2][4096] {};
+    i16 corrhist[2][CORRHIST_SIZE] {};
     HTable nhist[6] {};
     HTable conthist[12][64] {};
-    i16 corrhist[2][CORRHIST_SIZE] {};
-    int stack_eval[STACK_SIZE];
     HTable* stack_conthist[STACK_SIZE];
+    u64 nodes {};
     u64 visited[STACK_SIZE];
+    int stack_eval[STACK_SIZE];
     int visited_count;
     int id;
 


### PR DESCRIPTION
prefetch vs main
Elo   | 13.31 +- 7.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3840 W: 1174 L: 1027 D: 1639
Penta | [67, 408, 854, 493, 98]
https://analoghors.pythonanywhere.com/test/6972/

prefetch vs main
Elo   | 13.27 +- 6.63 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3354 W: 918 L: 790 D: 1646
Penta | [28, 340, 833, 428, 48]
https://analoghors.pythonanywhere.com/test/6973/