### PR TITLE
nmp fix ep hash update

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -106,6 +106,9 @@ struct Thread {
                 if (depth > 2 && eval >= beta && !is_nmp && board.colors[board.stm] & ~board.pieces[PAWN] & ~board.pieces[KING]) {
                     Board child = board;
 
+                    if (child.enpassant < SQUARE_NONE)
+                        child.hash ^= KEYS[PIECE_NONE][child.enpassant];
+
                     child.stm ^= 1;
                     child.hash ^= KEYS[PIECE_NONE][0];
                     child.enpassant = SQUARE_NONE;


### PR DESCRIPTION
nmp-ep-hash-fix vs main
Elo   | 5.98 +- 5.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 6160 W: 1806 L: 1700 D: 2654
Penta | [139, 734, 1254, 788, 165]
https://analoghors.pythonanywhere.com/test/6977/