### PR TITLE
contcorrhist

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -83,7 +83,8 @@ struct Thread {
             eval = stack_eval[ply] = board.eval() +
                 corrhist[board.stm][board.hash_pawn % CORRHIST_SIZE] / 128 +
                 corrhist[board.stm][board.hash_non_pawn[WHITE] % CORRHIST_SIZE] / 256 +
-                corrhist[board.stm][board.hash_non_pawn[BLACK] % CORRHIST_SIZE] / 256;
+                corrhist[board.stm][board.hash_non_pawn[BLACK] % CORRHIST_SIZE] / 256 +
+                (*stack_conthist[ply + 1])[0][0] / 128;
 
             // Use tt score as better eval
             if (tt.key && !excluded && tt.bound != tt.score < eval)
@@ -308,6 +309,7 @@ struct Thread {
             update_history(corrhist[board.stm][board.hash_pawn % CORRHIST_SIZE], bonus);
             update_history(corrhist[board.stm][board.hash_non_pawn[WHITE] % CORRHIST_SIZE], bonus);
             update_history(corrhist[board.stm][board.hash_non_pawn[BLACK] % CORRHIST_SIZE], bonus);
+            update_history((*stack_conthist[ply + 1])[0][0], bonus);
         }
 
         // Update transposition


### PR DESCRIPTION
contcorrhist vs main
Elo   | 13.27 +- 7.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4166 W: 1278 L: 1119 D: 1769
Penta | [103, 454, 850, 533, 143]
https://analoghors.pythonanywhere.com/test/6980/