### PR TITLE
smaller delta

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -335,14 +335,14 @@ struct Thread {
             stack_conthist[1] = &conthist[WHITE_PAWN][B1];
 
             // Aspiration window
-            int delta = 25;
+            int delta = 10;
             int alpha = score;
             int beta = score;
 
             while (score <= alpha || score >= beta) {
                 // Update window
-                alpha = score <= alpha ? score - delta : alpha;
-                beta = score >= beta ? score + delta : beta;
+                if (score <= alpha) alpha = score - delta;
+                if (score >= beta) beta = score + delta;
 
                 // Search
                 score = search(board, alpha, beta, 0, depth, TRUE);


### PR DESCRIPTION
aw-smaller-delta vs main
Elo   | 27.05 +- 10.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1892 W: 617 L: 470 D: 805
Penta | [35, 186, 392, 263, 70]
https://analoghors.pythonanywhere.com/test/6981/