### PR TITLE
revert nmp margin thingy

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -118,7 +118,7 @@ struct Thread {
 
                     stack_conthist[ply + 2] = conthist[WHITE_PAWN];
 
-                    int score = -search(child, -beta, -beta + 1, ply + 1, depth - 5 - depth / 3 - (eval - beta) / 256, FALSE, TRUE);
+                    int score = -search(child, -beta, -alpha, ply + 1, depth - 5 - depth / 3, FALSE, TRUE);
 
                     if (score >= beta)
                         return score < WIN ? score : beta;


### PR DESCRIPTION
revert-untested-stuff vs main
Elo   | -0.66 +- 2.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 48168 W: 13711 L: 13803 D: 20654
Penta | [1260, 5855, 9956, 5743, 1270]
https://analoghors.pythonanywhere.com/test/6982/