### PR TITLE
lmr more if not pv

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -215,7 +215,9 @@ struct Thread {
                     // Base reduction
                     log(depth) * log(legals) * 0.3 + 1 -
                     // History reduction
-                    is_quiet * move_scores[i] / 8192;
+                    is_quiet * move_scores[i] / 8192 +
+                    // PV
+                    !is_pv;
 
                 reduction *= reduction > 0;
 


### PR DESCRIPTION
lmr-pv vs main
Elo   | 9.63 +- 5.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6024 W: 1821 L: 1654 D: 2549
Penta | [138, 695, 1229, 762, 188]
https://analoghors.pythonanywhere.com/test/6992/