### PR TITLE
futility pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -184,7 +184,7 @@ struct Thread {
                 continue;
 
             // Futility pruning
-            if (ply && best > -WIN && depth < 10 && is_quiet && !board.checkers && stack_eval[ply] + 100 * depth + 100 < alpha)
+            if (ply && best > -WIN && depth < 10 && !board.checkers && stack_eval[ply] + 100 * depth + 100 < alpha && is_quiet)
                 continue;
 
             // SEE pruning


### PR DESCRIPTION
futility-pruning vs main
Elo   | 5.18 +- 3.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 13626 W: 3969 L: 3766 D: 5891
Penta | [340, 1587, 2822, 1658, 406]
https://analoghors.pythonanywhere.com/test/6993/