### PR TITLE
improving in rfp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -110,7 +110,7 @@ struct Thread {
             }
             else if (!is_pv && !excluded) {
                 // Reverse futility pruning
-                if (depth < 9 && eval < WIN && eval > beta + 70 * depth)
+                if (depth < 9 && eval < WIN && eval > beta + 70 * (depth - is_improving))
                     return eval;
 
                 // Null move pruning


### PR DESCRIPTION
rfp-improving vs main
Elo   | 9.52 +- 5.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6026 W: 1764 L: 1599 D: 2663
Penta | [143, 686, 1215, 801, 168]
https://analoghors.pythonanywhere.com/test/7000/