### PR TITLE
only do iir in pv nodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -79,7 +79,7 @@ struct Thread {
         }
         else
             // Internal iterative reduction
-            depth -= depth > 3;
+            depth -= is_pv && depth > 3;
 
         // Static eval
         stack_eval[ply] = INF;


### PR DESCRIPTION
iir-pv vs main
Elo   | 11.06 +- 6.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4966 W: 1485 L: 1327 D: 2154
Penta | [107, 565, 1017, 651, 143]
https://analoghors.pythonanywhere.com/test/7002/