### PR TITLE
preserve any existing move for the same position

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -321,7 +321,7 @@ struct Thread {
 
         // Update transposition
         if (!excluded)
-            slot = { u16(board.hash), best_move, i16(best), u8(depth), bound };
+            slot = { u16(board.hash), best_move || !tt.key ? best_move : slot.move, i16(best), u8(depth), bound };
 
         return best;
     }


### PR DESCRIPTION
tt-preserve-move vs main
Elo   | 39.13 +- 13.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1382 W: 500 L: 345 D: 537
Penta | [32, 118, 272, 201, 68]
https://analoghors.pythonanywhere.com/test/7005/