### PR TITLE
passer blocked

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -265,8 +265,13 @@ struct Board {
                             eval += (get_data(square / 8 + INDEX_PHALANX) + OFFSET_PHALANX) * SCALE;
 
                         // Passed pawns
-                        if (!(0x101010101010101 << square & (pawns_them | pawns_threats)))
+                        if (!(0x101010101010101 << square & (pawns_them | pawns_threats))) {
                             eval += (get_data(square / 8 + INDEX_PASSER) + OFFSET_PASSER) * SCALE;
+
+                            // Blocked passed pawn
+                            if (north(1ull << square) & colors[!color])
+                                eval -= PASSER_BLOCKED;
+                        }
                     }
                     else {
                         // Mobility

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -17,6 +17,7 @@ i32 PHASE[] { 0, 1, 1, 2, 4, 0 },
 #define PAWN_PROTECTED S(23, 24)
 #define PAWN_DOUBLED S(11, 37)
 #define PAWN_SHIELD S(28, -13)
+#define PASSER_BLOCKED S(5, 50)
 
 #define TEMPO 20
 


### PR DESCRIPTION
STC
```
passer-blocked vs main
Elo   | 7.03 +- 4.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9000 W: 2726 L: 2544 D: 3730
Penta | [232, 1022, 1845, 1134, 267]
```
https://analoghors.pythonanywhere.com/test/7039/

LTC
```
passer-blocked vs main
Elo   | 6.60 +- 4.54 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8478 W: 2462 L: 2301 D: 3715
Penta | [130, 965, 1924, 1054, 166]
```
https://analoghors.pythonanywhere.com/test/7040/