### PR TITLE
spsa tune 47k games

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -3,7 +3,7 @@
 #define S(MG, EG) (MG + (EG << 16))
 
 i32 PHASE[] { 0, 1, 1, 2, 4, 0 },
-    VALUE[] { 100, 320, 330, 500, 900, 2000, 0 },
+    VALUE[] { 110, 319, 294, 518, 912, 2000, 0 },
     LAYOUT[] { ROOK, KNIGHT, BISHOP, QUEEN, KING, BISHOP, KNIGHT, ROOK },
     MATERIAL[] { S(80, 100), S(200, 300), S(250, 350), S(400, 600), S(800, 1000), 0 };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -88,11 +88,11 @@ struct Thread {
         if (!board.checkers) {
             // Get eval
             eval = stack_eval[ply] = board.eval() +
-                corrhist[board.stm][board.hash_pawn % CORRHIST_SIZE] / 128 +
-                corrhist[board.stm][board.hash_non_pawn[WHITE] % CORRHIST_SIZE] / 256 +
-                corrhist[board.stm][board.hash_non_pawn[BLACK] % CORRHIST_SIZE] / 256 +
-                stack_conthist[ply + 1][0][0][0] / 128 +
-                stack_conthist[ply][0][1][0] / 200;
+                corrhist[board.stm][board.hash_pawn % CORRHIST_SIZE] / 137 +
+                corrhist[board.stm][board.hash_non_pawn[WHITE] % CORRHIST_SIZE] / 208 +
+                corrhist[board.stm][board.hash_non_pawn[BLACK] % CORRHIST_SIZE] / 208 +
+                stack_conthist[ply + 1][0][0][0] / 140 +
+                stack_conthist[ply][0][1][0] / 205;
 
             // Use tt score as better eval
             if (tt.key && !excluded && tt.bound != tt.score < eval)
@@ -110,7 +110,7 @@ struct Thread {
             }
             else if (!is_pv && !excluded) {
                 // Reverse futility pruning
-                if (depth < 9 && eval < WIN && eval > beta + 70 * (depth - is_improving))
+                if (depth < 9 && eval < WIN && eval > beta + 66 * (depth - is_improving))
                     return eval;
 
                 // Null move pruning
@@ -181,11 +181,11 @@ struct Thread {
                 continue;
 
             // Futility pruning
-            if (ply && best > -WIN && depth < 10 && !board.checkers && stack_eval[ply] + 100 * depth + 100 < alpha && is_quiet)
+            if (ply && best > -WIN && depth < 10 && !board.checkers && stack_eval[ply] + 96 * depth + 100 < alpha && is_quiet)
                 continue;
 
             // SEE pruning in pvsearch
-            if (ply && best > -WIN && move_scores[i] < 1e6 && !board.see(move, -80 * depth))
+            if (ply && best > -WIN && move_scores[i] < 1e6 && !board.see(move, -81 * depth))
                 continue;
 
             // Singular extension
@@ -195,7 +195,7 @@ struct Thread {
 
                 // Single extension + double extension
                 if (score < singular_beta)
-                    depth_next += 1 + (!is_pv && score + 16 < singular_beta);
+                    depth_next += 1 + (!is_pv && score + 13 < singular_beta);
 
                 // Multicut
                 else if (score >= beta)
@@ -217,9 +217,9 @@ struct Thread {
             if (depth > 2 && legals > 3) {
                 i32 reduction =
                     // Base reduction
-                    log(depth) * log(legals) * 0.3 + 1 -
+                    log(depth) * log(legals) * 0.35 + 1 -
                     // History reduction
-                    is_quiet * move_scores[i] / 8192 +
+                    is_quiet * move_scores[i] / 7792 +
                     // PV
                     !is_pv;
 
@@ -269,7 +269,7 @@ struct Thread {
                     break;
 
                 // History bonus
-                i32 bonus = min(150 * depth - 50, 1500);
+                i32 bonus = min(157 * depth - 54, 1485);
 
                 if (is_quiet) {
                     // Update quiet history


### PR DESCRIPTION
spsa-1-47k vs main
Elo   | 7.62 +- 4.93 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7158 W: 2067 L: 1910 D: 3181
Penta | [109, 810, 1601, 933, 126]
https://analoghors.pythonanywhere.com/test/7051/