### PR TITLE
lmr clamp noisy

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -224,7 +224,9 @@ struct Thread {
                     !is_pv;
 
                 reduction *= reduction > 0;
-                reduction = !is_quiet && reduction > 2 ? 2 : reduction;
+
+                if (!is_quiet && reduction > 2)
+                    reduction = 2;
 
                 score = -search(child, -alpha - 1, -alpha, ply + 1, depth_next - reduction);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -185,7 +185,7 @@ struct Thread {
                 continue;
 
             // SEE pruning in pvsearch
-            if (ply && best > -WIN && move_scores[i] < 1e6 && !board.see(move, -81 * depth))
+            if (ply && best > -WIN && move_scores[i] < 1e6 && !board.see(move, -81 * depth - is_quiet * move_scores[i] / 64))
                 continue;
 
             // Singular extension
@@ -224,6 +224,7 @@ struct Thread {
                     !is_pv;
 
                 reduction *= reduction > 0;
+                reduction = !is_quiet && reduction > 2 ? 2 : reduction;
 
                 score = -search(child, -alpha - 1, -alpha, ply + 1, depth_next - reduction);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -185,7 +185,7 @@ struct Thread {
                 continue;
 
             // SEE pruning in pvsearch
-            if (ply && best > -WIN && move_scores[i] < 1e6 && !board.see(move, -81 * depth - is_quiet * move_scores[i] / 64))
+            if (ply && best > -WIN && move_scores[i] < 1e6 && !board.see(move, -81 * depth))
                 continue;
 
             // Singular extension


### PR DESCRIPTION
lmr-clamp-noisy vs main
Elo   | 7.92 +- 5.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7636 W: 2293 L: 2119 D: 3224
Penta | [176, 876, 1595, 940, 231]
https://analoghors.pythonanywhere.com/test/7061/