### PR TITLE
double conthist weight

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -145,7 +145,10 @@ struct Thread {
                 // Hash move
                 move == tt.move ? 1e8 :
                 // Quiet moves
-                board.quiet(move) ? qhist[board.stm][move & 4095] + stack_conthist[ply][0][piece][move_to(move)] + stack_conthist[ply + 1][0][piece][move_to(move)] :
+                board.quiet(move) ?
+                    qhist[board.stm][move & 4095] +
+                    2 * stack_conthist[ply][0][piece][move_to(move)] +
+                    2 * stack_conthist[ply + 1][0][piece][move_to(move)] :
                 // Noisy moves
                 VALUE[victim] * 16 + VALUE[move_promo(move)] + nhist[victim][piece][move_to(move)] + board.see(move, 0) * 2e7 - 1e7;
         }


### PR DESCRIPTION
conthist-double vs main
Elo   | 4.58 +- 3.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 16316 W: 4782 L: 4567 D: 6967
Penta | [424, 1864, 3403, 2007, 460]
https://analoghors.pythonanywhere.com/test/7083/