### PR TITLE
better soft limit for time management

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -491,7 +491,7 @@ i32 main() {
                 tokens >> token >> time;
 
             STOP = FALSE;
-            LIMIT_SOFT = now() + time / 50;
+            LIMIT_SOFT = now() + time / 20;
             LIMIT_HARD = now() + time / 2;
 
 #ifdef OB


### PR DESCRIPTION
better-tm vs main
Elo   | 30.46 +- 10.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1658 W: 554 L: 409 D: 695
Penta | [23, 161, 349, 240, 56]
https://analoghors.pythonanywhere.com/test/7093/