### PR TITLE
nmp eval beta margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -114,7 +114,7 @@ struct Thread {
                     return eval;
 
                 // Null move pruning
-                if (depth > 2 && eval >= beta && board.colors[board.stm] & ~board.pieces[PAWN] & ~board.pieces[KING]) {
+                if (depth > 2 && eval > beta + 25 && board.colors[board.stm] & ~board.pieces[PAWN] & ~board.pieces[KING]) {
                     Board child = board;
 
                     child.stm ^= 1;


### PR DESCRIPTION
nmp-eval-margin vs main
Elo   | 8.58 +- 5.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7010 W: 2089 L: 1916 D: 3005
Penta | [184, 777, 1423, 924, 197]
https://analoghors.pythonanywhere.com/test/7105/