### PR TITLE
fp history margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -184,7 +184,7 @@ struct Thread {
                 continue;
 
             // Futility pruning
-            if (ply && best > -WIN && depth < 10 && !board.checkers && stack_eval[ply] + 96 * depth + 100 < alpha && is_quiet)
+            if (ply && best > -WIN && depth < 10 && !board.checkers && stack_eval[ply] + 96 * depth + move_scores[i] / 32 + 100 < alpha && is_quiet)
                 continue;
 
             // SEE pruning in pvsearch


### PR DESCRIPTION
fp-history-margin vs main
Elo   | 7.31 +- 4.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8560 W: 2557 L: 2377 D: 3626
Penta | [209, 982, 1762, 1074, 253]
https://analoghors.pythonanywhere.com/test/7111/