### PR TITLE
more bonus for better best score

### DIFF
--- a/minifier/mini.h
+++ b/minifier/mini.h
@@ -153,7 +153,9 @@ const inline std::vector<std::string> KEYWORDS_SKIP = {
     "thread",
     "join",
     "free",
-    "atomic_int"
+    "atomic_int",
+    "mutex",
+    "lock_guard"
 };
 
 const inline std::vector<std::string> KEYWORDS_STATEMENT = {
@@ -1407,11 +1409,11 @@ inline std::vector<std::string> get_removed_redundant_math(std::vector<std::stri
             }
 
             // Remove "+0" and "-0"
-            if ((token == "+" || token == "-") && i + 1 < tokens.size() && tokens[i + 1] == "0") {
+            if ((token == "+" || token == "-") && i + 1 < tokens.size() && tokens[i + 1] == "0" && (i + 2 >= tokens.size() || tokens[i + 2] != ".")) {
                 continue;
             }
 
-            if (token == "0" && i > 0 && (tokens[i - 1] == "+" || tokens[i - 1] == "-")) {
+            if (token == "0" && i > 0 && (tokens[i - 1] == "+" || tokens[i - 1] == "-") && (i + 1 >= tokens.size() || tokens[i + 1] != ".")) {
                 continue;
             }
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -107,7 +107,8 @@ struct Thread {
                 if (eval >= beta)
                     return eval;
 
-                if ((best = eval) > alpha) alpha = best;
+                if ((best = eval) > alpha)
+                    alpha = best;
             }
             else if (!is_pv && !excluded) {
                 // Reverse futility pruning
@@ -287,7 +288,7 @@ struct Thread {
                     break;
 
                 // History bonus
-                i32 bonus = min(157 * depth - 54, 1485);
+                i32 bonus = min(157 * depth - 54, 1485) + (stack_eval[ply] <= best) * 150;
 
                 if (is_quiet) {
                     // Update quiet history


### PR DESCRIPTION
history-bonus-eval-best vs main
Elo   | 9.98 +- 6.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5780 W: 1758 L: 1592 D: 2430
Penta | [131, 652, 1196, 742, 169]
https://analoghors.pythonanywhere.com/test/7153/