### PR TITLE
aspiration windows fix

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -367,6 +367,7 @@ struct Thread {
 
                 // Update window
                 if (score <= alpha)
+                    beta = (alpha + beta) / 2,
                     alpha = max(score - delta, -INF),
                     reduction = 0;
                 else if (score >= beta)


### PR DESCRIPTION
STC
aw-fix vs main
Elo   | 16.01 +- 7.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3258 W: 1010 L: 860 D: 1388
Penta | [67, 353, 662, 457, 90]
https://analoghors.pythonanywhere.com/test/7174/

LTC
aw-fix vs main
Elo   | 12.73 +- 6.51 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3550 W: 1014 L: 884 D: 1652
Penta | [30, 373, 860, 461, 51]
https://analoghors.pythonanywhere.com/test/7175/