### PR TITLE
singular extension closer beta

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -199,7 +199,7 @@ struct Thread {
 
             // Singular extension
             if (ply && depth > 7 && !excluded && move == tt.move && tt.depth > depth - 4 && tt.bound && abs(tt.score) < WIN) {
-                i32 singular_beta = tt.score - depth * 2;
+                i32 singular_beta = tt.score - depth;
                 score = search(board, singular_beta - 1, singular_beta, ply, (depth - 1) / 2, FALSE, move);
 
                 // Single extension + double extension


### PR DESCRIPTION
se-closer-beta vs main
Elo   | 2.56 +- 4.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 11004 W: 3135 L: 3054 D: 4815
Penta | [251, 1323, 2306, 1338, 284]
https://analoghors.pythonanywhere.com/test/7190/