### PR TITLE
lmr shallower and deeper

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -243,7 +243,10 @@ struct Thread {
                     (cutoff_count[ply + 1] > 3);
 
                 if (reduction > 0)
-                    score = -search(child, -alpha - 1, -alpha, ply + 1, depth_next - reduction);
+                    score = -search(child, -alpha - 1, -alpha, ply + 1, depth_next - reduction),
+
+                    // Shallower and deeper search
+                    depth_next += (score > best + 50) - (score < best + 8 && reduction > 1);
             }
 
             // Zero window search (don't do it for qsearch)


### PR DESCRIPTION
STC:
lmr-scale-next vs main
Elo   | 7.50 +- 4.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8016 W: 2299 L: 2126 D: 3591
Penta | [170, 894, 1730, 1021, 193]
https://analoghors.pythonanywhere.com/test/8231/

LTC:
lmr-scale-next vs main
Elo   | 16.17 +- 7.40 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2666 W: 751 L: 627 D: 1288
Penta | [19, 269, 649, 361, 35]
https://analoghors.pythonanywhere.com/test/8232/

size: 4084
bench: 6416963